### PR TITLE
Implement new API key getter and seeding files  reader logic, Update Nav tab and refresh page, 

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -486,3 +486,6 @@ appsettings.ApiKeys.json
 # Library / Modules dependencies files
 node_modules/
 .DS_Store
+
+# Seeding files
+backend/SeedFiles/

--- a/backend/backend/ApiClients/CurrencyBeacon/CurrencyBeaconApiClient.cs
+++ b/backend/backend/ApiClients/CurrencyBeacon/CurrencyBeaconApiClient.cs
@@ -76,8 +76,7 @@ public class CurrencyBeaconApiClient : IExchangeRateApiClient
         return currCountries;
     }
 
-    public async Task<SortedList<string, double>> GetExchangeRatesTimeSeries(string baseCurr, string targetCurr,
-        string timeSeriesRange)
+    public async Task<SortedList<string, double>> GetExchangeRatesTimeSeries(string baseCurr, string targetCurr, string timeSeriesRange)
     {
         CurrencyBeaconTimeSeriesApiResponse rateTimeSeriesApiResponse;
         if (isDevelopment)
@@ -119,8 +118,7 @@ public class CurrencyBeaconApiClient : IExchangeRateApiClient
         return startDate;
     }
 
-    private Dictionary<string, CurrCountriesResponse> TransformedCurrCountriesResData(
-        CurrencyBeaconCurrCountriesApiResponse currCountriesRes)
+    private Dictionary<string, CurrCountriesResponse> TransformedCurrCountriesResData(CurrencyBeaconCurrCountriesApiResponse currCountriesRes)
     {
         CurrencyBeaconCurrCountriesApiResponseResponse[] data = currCountriesRes.Response;
         Dictionary<string, CurrCountriesResponse> currCountries = new Dictionary<string, CurrCountriesResponse>();
@@ -141,8 +139,7 @@ public class CurrencyBeaconApiClient : IExchangeRateApiClient
         return currCountries;
     }
 
-    private SortedList<string, double> TransformedTimeSeriesResData(
-        CurrencyBeaconTimeSeriesApiResponse rateTimeSeriesApiResponse, string targetCurr)
+    private SortedList<string, double> TransformedTimeSeriesResData(CurrencyBeaconTimeSeriesApiResponse rateTimeSeriesApiResponse, string targetCurr)
     {
         var dateByRateLists = rateTimeSeriesApiResponse.Response;
         Dictionary<string, double> unsortedList = new Dictionary<string, double>();

--- a/backend/backend/ApiClients/CurrencyBeacon/CurrencyBeaconApiClient.cs
+++ b/backend/backend/ApiClients/CurrencyBeacon/CurrencyBeaconApiClient.cs
@@ -8,8 +8,9 @@ public class CurrencyBeaconApiClient : IExchangeRateApiClient
 {
     private readonly HttpClient _httpClient;
     private readonly ApiKeysProvider _apiKeysProvider;
-    private readonly string _currencyBeaconApiKey;
+    private string _currencyBeaconApiKey;
     private readonly ILogger<CurrencyBeaconApiClient> _logger;
+    private readonly bool isDevelopment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development";
 
     public CurrencyBeaconApiClient(HttpClient httpClient, ApiKeysProvider apiKeysProvider, ILogger<CurrencyBeaconApiClient> logger)
     {
@@ -36,8 +37,11 @@ public class CurrencyBeaconApiClient : IExchangeRateApiClient
         return currMapRates;
     }
 
-    public async Task<Dictionary<string, CurrCountriesResponse>> GetCurrCountries()
+    public async Task<Dictionary<string, CurrCountriesResponse>> GetCurrCountries(bool getAnotherApiKey)
     {
+        if (getAnotherApiKey)
+            _currencyBeaconApiKey = _apiKeysProvider.GetApiKey(ApiKeysProvider.ApiName.CurrencyBeaconApiKey);
+
         string url = "https://api.currencybeacon.com/v1/currencies?api_key=" + _currencyBeaconApiKey;
         var currCountriesResponse = await _httpClient.GetFromJsonAsync<CurrencyBeaconCurrCountriesApiResponse>(url);
         Dictionary<string, CurrCountriesResponse> currCountries =  TransformedCurrCountriesResData(currCountriesResponse);

--- a/backend/backend/ApiClients/RapidApi/RapidApiApiClient.cs
+++ b/backend/backend/ApiClients/RapidApi/RapidApiApiClient.cs
@@ -8,7 +8,7 @@ public class RapidApiApiClient : IFinancialNewsApiClient
 {
     private readonly HttpClient _httpClient;
     private readonly ApiKeysProvider _apiKeysProvider;
-    private readonly string _rapidApiApiKey;
+    private  string _rapidApiApiKey;
 
     public RapidApiApiClient(HttpClient httpClient, ApiKeysProvider apiKeysProvider)
     {
@@ -20,8 +20,11 @@ public class RapidApiApiClient : IFinancialNewsApiClient
         _httpClient.DefaultRequestHeaders.Add("X-RapidAPI-Host", "apidojo-yahoo-finance-v1.p.rapidapi.com");
     }
     
-    public async Task<FinancialNewsResponse[]> GetFinancialNews(string newsTopic)
+    public async Task<FinancialNewsResponse[]> GetFinancialNews(string newsTopic, bool getAnotherApiKey)
     {
+        if (getAnotherApiKey)
+            UpdateApiKey();
+
         string url = "/auto-complete?q=" + newsTopic + "&region=US";
         var financialNewsList = await RetrieveDataFromApi(url)!;
         return financialNewsList;
@@ -82,5 +85,18 @@ public class RapidApiApiClient : IFinancialNewsApiClient
     private string FormatDateTime(DateTime newsPublishTime)
     {
         return newsPublishTime.ToString("ddd, MMM dd, yyyy HH:mm", CultureInfo.InvariantCulture);
+    }
+
+    private void UpdateApiKey()
+    {
+        string newApiKey = _apiKeysProvider.GetApiKey(ApiKeysProvider.ApiName.RapidApiApiKey);
+
+        if (_httpClient.DefaultRequestHeaders.Contains("X-RapidAPI-Key"))
+        {
+            _httpClient.DefaultRequestHeaders.Remove("X-RapidAPI-Key");
+        }
+
+        _httpClient.DefaultRequestHeaders.Add("X-RapidAPI-Key", newApiKey);
+        _rapidApiApiKey = newApiKey;
     }
 }

--- a/backend/backend/ApiKeysProvider.cs
+++ b/backend/backend/ApiKeysProvider.cs
@@ -23,7 +23,7 @@ public class ApiKeysProvider
     public ApiKeysProvider(ILogger<ApiKeysProvider> logger, IWebHostEnvironment env)
     {
         // Determined on how to retrieve API key
-        // if in developement env. then grab from AppSettings.json, else grab from environment variable instead.
+        // if in developement env. then grab all the api keys from AppSettings.json, else grab from environment variable instead.
         if (env.IsDevelopment())
             _apiKeysConfiguration = ReadApiKeysFromJson();
         _logger = logger;

--- a/backend/backend/ApiKeysProvider.cs
+++ b/backend/backend/ApiKeysProvider.cs
@@ -1,8 +1,3 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using Microsoft.Extensions.Configuration;
-using System;
-
 namespace backend;
 
 public class ApiKeysProvider

--- a/backend/backend/Interfaces/IExchangeRateApiClient.cs
+++ b/backend/backend/Interfaces/IExchangeRateApiClient.cs
@@ -6,6 +6,6 @@ public interface IExchangeRateApiClient
 {
     Task<Dictionary<string, double>> GetLatestExchangeRates(string baseCurr);
     Task<Dictionary<string, double>> GetHistoricalExchangeRates(string baseCurr);
-    Task<Dictionary<string, CurrCountriesResponse>> GetCurrCountries();
+    Task<Dictionary<string, CurrCountriesResponse>> GetCurrCountries(bool getAnotherApiKey);
     Task<SortedList<string, double>> GetExchangeRatesTimeSeries(string baseCurr, string targetCurr, string timeSeriesRange);
 }

--- a/backend/backend/Interfaces/IFinancialNewsApiClient.cs
+++ b/backend/backend/Interfaces/IFinancialNewsApiClient.cs
@@ -4,5 +4,5 @@ namespace backend.Interfaces;
 
 public interface IFinancialNewsApiClient
 {
-    Task<FinancialNewsResponse[]> GetFinancialNews(string newsTopic);
+    Task<FinancialNewsResponse[]> GetFinancialNews(string newsTopic, bool getAnotherApiKey);
 }

--- a/backend/backend/Services/FinancialNewsService.cs
+++ b/backend/backend/Services/FinancialNewsService.cs
@@ -6,10 +6,13 @@ namespace backend.Services;
 public class FinancialNewsService
 {
     private readonly List<IFinancialNewsApiClient> _financialNewsApiClients;
+    private readonly ILogger<FinancialNewsService> _logger;
+    private int TotalRetryApiKey { get; set; } = 3;
 
-    public FinancialNewsService(IEnumerable<IFinancialNewsApiClient> financialNewsApiClients)
+    public FinancialNewsService(IEnumerable<IFinancialNewsApiClient> financialNewsApiClients, ILogger<FinancialNewsService> logger)
     {
         _financialNewsApiClients = financialNewsApiClients.ToList();
+        _logger = logger;
     }
 
     public async Task<FinancialNewsResponse[]> GetFinancialNews(string newsTopic)
@@ -19,12 +22,36 @@ public class FinancialNewsService
         {
             try
             {
-                news = await apiClient.GetFinancialNews(newsTopic);
-            } catch (Exception e)
+                TotalRetryApiKey--;
+                news = await apiClient.GetFinancialNews(newsTopic, false);
+            }
+            catch (Exception e)
             {
-                Console.WriteLine("Cannot retrieve news: " + e);
+                news = await RetryToGetFinancialNews(apiClient, news, newsTopic);
+
+                if (news is null)
+                {
+                    _logger.LogInformation("Cannot retrieve news: " + e);
+                    Console.WriteLine("Cannot retrieve news: " + e);
+                }
             }
         }
         return news;
+    }
+
+    private async Task<FinancialNewsResponse[]> RetryToGetFinancialNews(IFinancialNewsApiClient apiClient, FinancialNewsResponse[] response, string newsTopic)
+    {
+        while (TotalRetryApiKey > 0 && response is null)
+        {
+            response = await apiClient.GetFinancialNews(newsTopic, true); // invoke method again by trying to use another api key
+            TotalRetryApiKey--;
+
+            if (response is not null)
+                break;
+            else if (TotalRetryApiKey == 0)
+                _logger.LogInformation($"None of the currCountries api key works!!!");
+        }
+        TotalRetryApiKey = 3; // reset total retry api key when data return
+        return response;
     }
 }

--- a/backend/backend/Services/FinancialNewsService.cs
+++ b/backend/backend/Services/FinancialNewsService.cs
@@ -24,6 +24,9 @@ public class FinancialNewsService
             {
                 TotalRetryApiKey--;
                 news = await apiClient.GetFinancialNews(newsTopic, false);
+
+                if (news is null)
+                    throw new NullReferenceException();
             }
             catch (Exception e)
             {

--- a/backend/backend/Utilities/JsonSeedFilesReader.cs
+++ b/backend/backend/Utilities/JsonSeedFilesReader.cs
@@ -1,0 +1,66 @@
+﻿using System.Text.Json;
+
+namespace backend.Utilities;
+
+public class JsonSeedFilesReader
+{
+	public JsonSeedFilesReader()
+	{
+
+    }
+
+    /// <summary>
+    /// Attempting to retrieved curr data from seeding files instead of requesting the actual api data, in order to prevent the api key run out of quota.
+    /// This function only works with DotNET debugging mode, not on docker. This is becuase the dockerized app cannot access files out, such as project root dir
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="relativePath"></param>
+    /// <returns></returns>
+    public static async Task<T> ReadCurrFromJson<T>(string relativePath)
+    {
+        try
+        {
+            string basePath = GetProjectRootPath() + "/SeedFiles";
+            string filePath = basePath + relativePath;
+            // Read the JSON file asynchronously
+            using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
+            {
+                // Deserialize the JSON content to CurrencyBeaconTimeSeriesApiResponse
+                var apiResponse = await JsonSerializer.DeserializeAsync<T>(stream);
+                return apiResponse;
+            }
+        }
+        catch (Exception ex)
+        {
+            // Handle or log the exception as needed
+            Console.WriteLine($"An error occurred while reading or deserializing the JSON file: {ex.Message}");
+            return default(T);
+        }
+    }
+
+    /// <summary>
+    /// Getting relative file path to access static json seed file for development environtment only
+    /// </summary>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public static string GetProjectRootPath()
+    {
+        var baseDirectory = AppContext.BaseDirectory;
+        var currentDirectory = new DirectoryInfo(baseDirectory);
+
+        // Traverse up the directory structure to find the project root (assuming typical bin/Debug or bin/Release structure)
+        while (currentDirectory != null && currentDirectory.Name != "bin")
+        {
+            currentDirectory = currentDirectory.Parent;
+        }
+
+        // If found, move one directory up to the project root
+        if (currentDirectory != null)
+        {
+            return currentDirectory.Parent.FullName;
+        }
+
+        throw new InvalidOperationException("Could not determine the project root directory.");
+    }
+}
+

--- a/backend/backend/backend.csproj
+++ b/backend/backend/backend.csproj
@@ -21,6 +21,15 @@
       <Content Update="appsettings.ApiKeys.json">
         <CopyToPublishDirectory>Never</CopyToPublishDirectory>
       </Content>
+      <Content Condition="'$(ExcludeConfigFilesFromBuildOutput)'!='true'" Update="appsettings.Environment.json">
+        <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+      </Content>
     </ItemGroup>
 
+    <ItemGroup>
+      <None Remove="SeedFiles\" />
+    </ItemGroup>
+    <ItemGroup>
+      <Folder Include="SeedFiles\" />
+    </ItemGroup>
 </Project>

--- a/backend/backend/backend.csproj
+++ b/backend/backend/backend.csproj
@@ -28,8 +28,10 @@
 
     <ItemGroup>
       <None Remove="SeedFiles\" />
+      <None Remove="Utilities\" />
     </ItemGroup>
     <ItemGroup>
       <Folder Include="SeedFiles\" />
+      <Folder Include="Utilities\" />
     </ItemGroup>
 </Project>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,7 +15,7 @@ export default function App() {
     const isDisplaySM = useMediaQuery('(max-width:414px)');
     const isDisplayMD = useMediaQuery('(max-width:920px)');
     const currentUrl = useLocation();
-    const { currCountiesCodeMapDetail, isReady } = useCurrCountriesApiGetter(currentUrl);
+    const { currCountiesCodeMapDetail, isReady } = useCurrCountriesApiGetter();
 
     const Item = styled(Paper)(({ theme }) => ({
         height: 'auto',

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -14,8 +14,8 @@ export default function App() {
     const [isOutLineTheme, setIsOutLineTheme] = useState(false); // setting theme
     const isDisplaySM = useMediaQuery('(max-width:414px)');
     const isDisplayMD = useMediaQuery('(max-width:920px)');
-    const { currCountiesCodeMapDetail, isReady } = useCurrCountriesApiGetter();
     const currentUrl = useLocation();
+    const { currCountiesCodeMapDetail, isReady } = useCurrCountriesApiGetter(currentUrl);
 
     const Item = styled(Paper)(({ theme }) => ({
         height: 'auto',

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -41,7 +41,7 @@ export default function App() {
 
     return (
         <div className="App">
-            <MainNav isDisplaySM={isDisplaySM} isOutLineTheme={isOutLineTheme} onChangeTheme={handleThemeChange} currentUrl={currentUrl}/>
+            <MainNav isDisplaySM={isDisplaySM} isDisplayMD={isDisplayMD} isOutLineTheme={isOutLineTheme} onChangeTheme={handleThemeChange} currentUrl={currentUrl}/>
             <ThemeProvider theme={lightTheme}>
                 <Routes>
                     <Route exact path="/" element={

--- a/frontend/src/components/About.js
+++ b/frontend/src/components/About.js
@@ -1,7 +1,0 @@
-
-
-export function About() {
-    return (
-        
-    )
-}

--- a/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
+++ b/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
@@ -161,7 +161,7 @@ export default function ExchangeRateTableData(props) {
         const oldTargetCurrCodeArray = [...currCodeArray];
 
         for (let i in oldCurrLists) {
-            if (oldCurrLists[i].targetCurr === targetCurr && targetCurr !== targetCurr) {
+            if (oldCurrLists[i].targetCurr === targetCurr && targetCurr !== defaultCurrCode) {
                 oldCurrLists.splice(i, 1);
                 oldTargetCurrCodeArray.splice(i, 1);
             }

--- a/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
+++ b/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
@@ -71,7 +71,7 @@ export default function ExchangeRateTableData(props) {
 
     // refresh time display on screen when any time-related property is updated
     useEffect(() => {
-        console.log("Update new display time!!!");
+        // console.log("Update new display time!!!");
         handleUpdateRateTime();
     }, [triggerNewTimeDisplay]);
 

--- a/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
+++ b/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
@@ -7,8 +7,6 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TablePagination from '@mui/material/TablePagination';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Switch from '@mui/material/Switch';
 import Button from '@mui/material/Button';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
@@ -45,6 +43,7 @@ export default function ExchangeRateTableData(props) {
     const [page, setPage] = useState(0);
     const [dense, setDense] = useState(false);
     const [rowsPerPage, setRowsPerPage] = useState(5);
+    const [triggerNewTimeDisplay, setTriggerNewTimeDisplay] = useState(false);
 
     useEffect(() => {
         if (isReady) {
@@ -70,6 +69,12 @@ export default function ExchangeRateTableData(props) {
         checkNewRow();
     }, [newCurrCode, currLists, currDataSet, defaultCurrCode, currCodeArray]);
 
+    // refresh time display on screen when any time-related property is updated
+    useEffect(() => {
+        console.log("Update new display time!!!");
+        handleUpdateRateTime();
+    }, [triggerNewTimeDisplay]);
+
     const handleRequestSort = (event, property) => {
         const isAsc = orderBy === property && order === 'asc';
         setOrder(isAsc ? 'desc' : 'asc');
@@ -79,7 +84,7 @@ export default function ExchangeRateTableData(props) {
     const handleUpdateRateTime = () => {
         const newDate = new Date();
         const updateTime = newDate.toDateString().slice(4, -5) + ", " + newDate.toDateString().slice(-5) + ", "
-            + newDate.toLocaleTimeString('en-US', { hour12: false }).slice(0, -3);
+            + newDate.toLocaleTimeString('en-US', { hour12: false })//;.slice(0, -3);
         setLastUpdateRateTime(updateTime);
     }
 
@@ -301,8 +306,10 @@ export default function ExchangeRateTableData(props) {
                             <CircularProgressWithLabel
                                 sx={sxStyle.progressBar}
                                 onUpdateNewLiveRate={updateNewLiveRate}
+                                onUpdateDisplayTime={() => setTriggerNewTimeDisplay(!triggerNewTimeDisplay)}
                                 lastUpdateRateTime={lastUpdateRateTime}
                                 isDisplaySM={isDisplaySM}
+                                isDisplayMD={isDisplayMD}
                             />
                         }
                     </Box>
@@ -322,6 +329,7 @@ export default function ExchangeRateTableData(props) {
                             <CircularProgressWithLabel
                                 sx={sxStyle.progressBar}
                                 onUpdateNewLiveRate={updateNewLiveRate}
+                                onUpdateDisplayTime={() => setTriggerNewTimeDisplay(!triggerNewTimeDisplay)}
                                 lastUpdateRateTime={lastUpdateRateTime}
                                 isDisplaySM={isDisplaySM}
                                 isDisplayMD={isDisplayMD}

--- a/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
+++ b/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
@@ -161,6 +161,7 @@ export default function ExchangeRateTableData(props) {
         const oldTargetCurrCodeArray = [...currCodeArray];
 
         for (let i in oldCurrLists) {
+            // only delete the currency in the list that match targetCurr, but not defaultCurr 
             if (oldCurrLists[i].targetCurr === targetCurr && targetCurr !== defaultCurrCode) {
                 oldCurrLists.splice(i, 1);
                 oldTargetCurrCodeArray.splice(i, 1);

--- a/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
+++ b/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
@@ -328,13 +328,13 @@ export default function ExchangeRateTableData(props) {
                         </Box>
                     }
                 </Paper>
-                {isDisplaySM ? "" :
+                {/* {isDisplaySM ? "" :
                     <FormControlLabel
                         control={<Switch checked={dense} onChange={updateNewLiveRate} />}
                         label="Dense padding"
                         sx={{ display: 'none' }}
                     />
-                }
+                } */}
             </Box >
             }
         </>

--- a/frontend/src/components/LineGraph.js
+++ b/frontend/src/components/LineGraph.js
@@ -3,18 +3,19 @@ import { Chart as Chartjs } from 'chart.js/auto';
 import { Box } from '@mui/material';
 
 export function LineGraph(props) {
-    const { displayLabel = false, timeSeries } = props;
-    const changingRates = timeSeries.changingRates;
-    const timeSeriesRangeLabel = changingRates.length <= 31 ? timeSeries.dayRangeIndicator : timeSeries.monthRangeIndicator;
+    const { displayLabel = false, timeSeries = null } = props;
+    // console.log("Check passing in TimeSeries: ", timeSeries); // for debugging the response data
+    const changingRates = timeSeries !== null ? timeSeries.changingRates : null;
+    const timeSeriesRangeLabel = timeSeries !== null ? (changingRates.length <= 31 ? timeSeries.dayRangeIndicator : timeSeries.monthRangeIndicator) : "1d";
     const borderColor = () => {
-        if (changingRates[0] > changingRates[changingRates.length - 1]) {
+        if (changingRates !== null && changingRates[0] > changingRates[changingRates.length - 1]) {
             return '#cd0000';
         } else {
             return '#0ba50b'
         }
     }
     const backgroundColor = () => {
-        if (changingRates[0] > changingRates[changingRates.length - 1]) {
+        if (changingRates !== null && changingRates[0] > changingRates[changingRates.length - 1]) {
             return '#cd0000b0';
         } else {
             return '#0ba50bb0'

--- a/frontend/src/components/MainNav.js
+++ b/frontend/src/components/MainNav.js
@@ -53,10 +53,8 @@ export default function MainNav(props) {
                     </Typography>
                     <Box sx={sxStyle.BoxSub}>
                         {navItems.map((item) => {
-                            const isCurrentPage = currentUrl.pathname === "/" && item.link.substring(item.link.indexOf("/") - 1) === "/" || currentUrl.pathname !== "/" && item.link.substring(item.link.indexOf("/")).includes(currentUrl.pathname.substring(1));
-                            console.log("check item.link: ", item.link);
-                            console.log("check currentUrl: ", currentUrl.pathname);
-                            console.log("check isCurrentPage: ", isCurrentPage);
+                            const isCurrentPage = (item.link.substring(item.link.indexOf("/") - 1) === currentUrl.pathname) // when current url is at homePage, '/' 
+                                                    || (currentUrl.pathname !== "/" && item.link.substring(item.link.indexOf("/")).includes(currentUrl.pathname.substring(1)));
                             return (
                                 <>
                                     <Link

--- a/frontend/src/components/MainNav.js
+++ b/frontend/src/components/MainNav.js
@@ -171,7 +171,7 @@ const PopupSideBar = ({ navItems, handleDrawerToggle, isOutLineTheme, onChangeTh
                 {navItems.map((item) => (
                     <ListItem key={item.label} disablePadding>
                         <ListItemButton sx={sxStyle.ListItemButtonPopupSideBar} href={item.link} >
-                            <ListItemText primary={item.label} sx={{}} />
+                            <ListItemText primary={item.label} />
                         </ListItemButton>
                     </ListItem>
                 ))}

--- a/frontend/src/components/MainNav.js
+++ b/frontend/src/components/MainNav.js
@@ -61,25 +61,23 @@ export default function MainNav(props) {
                             const isCurrentPage = (item.link.substring(item.link.indexOf("/") - 1) === currentUrl.pathname) // when current url is at homePage, '/' 
                                                     || (currentUrl.pathname !== "/" && item.link.substring(item.link.indexOf("/")).includes(currentUrl.pathname.substring(1)));
                             return (
-                                <>
-                                    <Link
-                                        id="navPage"
-                                        to={item.link}
-                                        key={item.label}
-                                        style={{
-                                            ...sxStyle.Link,
-                                            ...sxStyle.NonMargin,
-                                            ...(isCurrentPage && {
-                                                ...(isOutLineTheme ? commonStyles.navPageBorderBottom.Outline : commonStyles.navPageBorderBottom.Elevate),
-                                            }),
-                                        }}
-                                        onClick={() => handleRefreshPage(item.link)}
-                                    >
-                                        <Box sx={{ ...sxStyle.Link, ...(isCurrentPage && commonStyles.subNavPageMargin) }}>
-                                            {isDisplayMD ? item.label.substring(item.label.indexOf(" ")) : item.label}
-                                        </Box>
-                                    </Link>
-                                </>
+                                <Link
+                                    id="navPage"
+                                    to={item.link}
+                                    key={item.label}
+                                    style={{
+                                        ...sxStyle.Link,
+                                        ...sxStyle.NonMargin,
+                                        ...(isCurrentPage && {
+                                            ...(isOutLineTheme ? commonStyles.navPageBorderBottom.Outline : commonStyles.navPageBorderBottom.Elevate),
+                                        }),
+                                    }}
+                                    onClick={() => handleRefreshPage(item.link)}
+                                >
+                                    <Box sx={{ ...sxStyle.Link, ...(isCurrentPage && commonStyles.subNavPageMargin) }}>
+                                        {isDisplayMD ? item.label.substring(item.label.indexOf(" ")) : item.label}
+                                    </Box>
+                                </Link>
                             )
                         })}
                         <FormControl component="fieldset" variant="standard" sx={sxStyle.themeSetter}>

--- a/frontend/src/components/MainNav.js
+++ b/frontend/src/components/MainNav.js
@@ -53,9 +53,9 @@ export default function MainNav(props) {
                     </Typography>
                     <Box sx={sxStyle.BoxSub}>
                         {navItems.map((item) => {
-                            const isCurrentPage = item.link.includes(currentUrl.pathname);
+                            const isCurrentPage = currentUrl.pathname === "/" && item.link.substring(item.link.indexOf("/") - 1) === "/" || currentUrl.pathname !== "/" && item.link.substring(item.link.indexOf("/")).includes(currentUrl.pathname.substring(1));
                             console.log("check item.link: ", item.link);
-                            console.log("check currentUrl: ", currentUrl);
+                            console.log("check currentUrl: ", currentUrl.pathname);
                             console.log("check isCurrentPage: ", isCurrentPage);
                             return (
                                 <>
@@ -121,9 +121,9 @@ export default function MainNav(props) {
 
 const mainLogo = { label: 'KCURR', link: "/" }
 const navItems = [
+    { label: 'Dashboard', link: "/" },
     { label: 'Convertor', link: "/convertor" },
     { label: 'Financial News', link: "/financial-news" },
-    { label: 'About', link: "/about" },
     { label: 'Contact', link: "/contact" },
 ];
 

--- a/frontend/src/components/MainNav.js
+++ b/frontend/src/components/MainNav.js
@@ -18,7 +18,7 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 
 export default function MainNav(props) {
-    const { isDisplaySM, isOutLineTheme, onChangeTheme, currentUrl } = props;
+    const { isDisplaySM, isDisplayMD, isOutLineTheme, onChangeTheme, currentUrl } = props;
 
     const [mobileScreen, setMobileScreen] = useState(false);
     const [state, setState] = useState(isOutLineTheme);
@@ -70,7 +70,7 @@ export default function MainNav(props) {
                                         }}
                                     >
                                         <Box sx={{ ...sxStyle.Link, ...(isCurrentPage && commonStyles.subNavPageMargin) }}>
-                                            {item.label}
+                                            {isDisplayMD ? item.label.substring(item.label.indexOf(" ")) : item.label}
                                         </Box>
                                     </Link>
                                 </>

--- a/frontend/src/components/MainNav.js
+++ b/frontend/src/components/MainNav.js
@@ -32,6 +32,11 @@ export default function MainNav(props) {
         setMobileScreen((horizontalScreen) => !horizontalScreen);
     };
 
+    const handleRefreshPage = (link) => {
+        if (link === currentUrl.pathname)
+            window.location.reload();
+    }
+
     return (
         <Box
             display='flex'
@@ -68,6 +73,7 @@ export default function MainNav(props) {
                                                 ...(isOutLineTheme ? commonStyles.navPageBorderBottom.Outline : commonStyles.navPageBorderBottom.Elevate),
                                             }),
                                         }}
+                                        onClick={() => handleRefreshPage(item.link)}
                                     >
                                         <Box sx={{ ...sxStyle.Link, ...(isCurrentPage && commonStyles.subNavPageMargin) }}>
                                             {isDisplayMD ? item.label.substring(item.label.indexOf(" ")) : item.label}

--- a/frontend/src/hook/useCurrCountriesApiGetter.js
+++ b/frontend/src/hook/useCurrCountriesApiGetter.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 
-export default function useCurrCountriesApiGetter(currentUrl) {
+export default function useCurrCountriesApiGetter() {
     const [currCountiesCodeMapDetail, setCurrCountiesCodeMapDetail] = useState({});
     const [isReady, setIsReady] = useState(false);
 

--- a/frontend/src/hook/useCurrCountriesApiGetter.js
+++ b/frontend/src/hook/useCurrCountriesApiGetter.js
@@ -11,7 +11,6 @@ export default function useCurrCountriesApiGetter(currentUrl) {
     useEffect(
         function fetchData() {
             async function fetchCurrOption() {
-                if (!currentUrl.pathname.toLowerCase().includes("news")) {
                     let resCurrCountries;
                     let isValidResponse = false;
                     let retryFetching = 5;
@@ -42,10 +41,6 @@ export default function useCurrCountriesApiGetter(currentUrl) {
                             retryFetching--;
                         }
                     }
-                } 
-                else {
-                    return { currCountiesCodeMapDetail, isReady };
-                }
             }
             fetchCurrOption();
         }, [baseURL]

--- a/frontend/src/hook/useCurrCountriesApiGetter.js
+++ b/frontend/src/hook/useCurrCountriesApiGetter.js
@@ -1,8 +1,7 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 
-export default function useCurrCountriesApiGetter() {
-
+export default function useCurrCountriesApiGetter(currentUrl) {
     const [currCountiesCodeMapDetail, setCurrCountiesCodeMapDetail] = useState({});
     const [isReady, setIsReady] = useState(false);
 
@@ -12,35 +11,40 @@ export default function useCurrCountriesApiGetter() {
     useEffect(
         function fetchData() {
             async function fetchCurrOption() {
-                let resCurrCountries;
-                let isValidResponse = false;
-                let retryFetching = 5;
+                if (!currentUrl.pathname.toLowerCase().includes("news")) {
+                    let resCurrCountries;
+                    let isValidResponse = false;
+                    let retryFetching = 5;
 
-                while (!isValidResponse && retryFetching > 0) {
-                    // console.log(`Requesting data on: ${baseURL}:${port}`); // Debugging frontend request and backend response
+                    while (!isValidResponse && retryFetching > 0) {
+                        // console.log(`Requesting data on: ${baseURL}:${port}`); // Debugging frontend request and backend response
 
-                    try {
-                        resCurrCountries = await axios.get(`${baseURL}:${port}/curr/currency-country`);
-                    } catch (e) {
-                        console.log(e.stack);
-                    }
-                    if (resCurrCountries !== undefined) {
-                        if (Object.keys(resCurrCountries.data).length) {
-                            setCurrCountiesCodeMapDetail(resCurrCountries.data);
-                            setIsReady(true);
-                            isValidResponse = true; // Stop the loop
-                            // console.log(`Successfully received currency-country data!!!`);
+                        try {
+                            resCurrCountries = await axios.get(`${baseURL}:${port}/curr/currency-country`);
+                        } catch (e) {
+                            console.log(e.stack);
                         }
-                        else {
-                            console.log(`Data not found!!!`);
+                        if (resCurrCountries !== undefined) {
+                            if (Object.keys(resCurrCountries.data).length) {
+                                setCurrCountiesCodeMapDetail(resCurrCountries.data);
+                                setIsReady(true);
+                                isValidResponse = true; // Stop the loop
+                                // console.log(`Successfully received currency-country data!!!`);
+                            }
+                            else {
+                                console.log(`Data not found!!!`);
+                            }
+                        }
+
+                        if (!isValidResponse) {
+                            // Optionally, you can add a delay before retrying
+                            await new Promise(resolve => setTimeout(resolve, 1000)); // 1-second delay before retrying
+                            retryFetching--;
                         }
                     }
-
-                    if (!isValidResponse) {
-                        // Optionally, you can add a delay before retrying
-                        await new Promise(resolve => setTimeout(resolve, 1000)); // 1-second delay before retrying
-                        retryFetching--;
-                    }
+                } 
+                else {
+                    return { currCountiesCodeMapDetail, isReady };
                 }
             }
             fetchCurrOption();

--- a/frontend/src/hook/useCurrCountriesApiGetter.js
+++ b/frontend/src/hook/useCurrCountriesApiGetter.js
@@ -43,7 +43,7 @@ export default function useCurrCountriesApiGetter() {
                     }
             }
             fetchCurrOption();
-        }, [baseURL]
+        }, [baseURL, port]
     );
     return { currCountiesCodeMapDetail, isReady };
 };

--- a/frontend/src/util/CircularProgressWithLabel.js
+++ b/frontend/src/util/CircularProgressWithLabel.js
@@ -53,16 +53,22 @@ CircularProgressWithLabel.propTypes = {
 };
 
 export default function CircularWithValueLabel(props) {
-    const [progress, setProgress] = useState(60);
-    const { onUpdateNewLiveRate, lastUpdateRateTime, isDisplaySM, isDisplayMD } = props;
+    const { onUpdateNewLiveRate, onUpdateDisplayTime, lastUpdateRateTime, isDisplaySM, isDisplayMD } = props;
+    const [progress, setProgress] = useState(59);
+    const [timerForUpdateNewLiveRate, setTimerForUpdateNewLiveRate] = useState(15); // reduce the frequency of retrieving new rate from run out of quota
 
     const checkTimer = (prevProgress) => {
-        if (prevProgress <= 0) {
+        if (prevProgress <= 2) {  // 1.66 * 60 = 99.6
             // console.log('Reset timer and Refresh lives rate!!!');
-            onUpdateNewLiveRate();
-            prevProgress = 100;
+            prevProgress = 99.6;
+            setTimerForUpdateNewLiveRate(timerForUpdateNewLiveRate - 1);
+            if (timerForUpdateNewLiveRate == 0) {
+                onUpdateNewLiveRate();
+                setTimerForUpdateNewLiveRate(15);
+            }
+            onUpdateDisplayTime();
         } else {
-            prevProgress -= 1.667;
+            prevProgress -= 1.6666666667;
         }
         return prevProgress;
     }
@@ -74,10 +80,10 @@ export default function CircularWithValueLabel(props) {
         return () => {
             clearInterval(timer);
         };
-    }, [progress, lastUpdateRateTime, isDisplaySM, isDisplayMD]);
+    }, [progress, lastUpdateRateTime, timerForUpdateNewLiveRate, isDisplaySM, isDisplayMD]);
 
     useEffect(() => {
-        getUpdateTime(lastUpdateRateTime);
+        setUpdateTime(lastUpdateRateTime);
     }, [lastUpdateRateTime]);
 
     useEffect(() => {
@@ -105,7 +111,7 @@ var updateTime = 0;
 var displaySM = false;
 var displayMD = false;
 
-const getUpdateTime = (time) => {
+const setUpdateTime = (time) => {
     updateTime = time;
 }
 

--- a/frontend/src/util/getFlag.js
+++ b/frontend/src/util/getFlag.js
@@ -1,15 +1,29 @@
 export function getFlag(currCountry) {
     if (currCountry == null || currCountry.substring(0, 1) === "X") {
-        return <div style={style.divGetFlag} >{currCountry}</div>
+        return <div style={{...style.flagImg, ...style.divGetFlag}} >{currCountry}</div>
     } else {
-        return <img style={style.flagImg} src={getBaseUrl(currCountry)} alt="" />
+        const url = getBaseUrl(currCountry);
+        if (UrlExists(url))
+            return <img style={style.flagImg} src={getBaseUrl(currCountry)} alt=""/>
+        else
+            return <div style={{...style.flagImg, ...style.divGetFlag}} >{currCountry}</div>
     }
 };
 
 const getBaseUrl = (currCountry) => {
     return `https://purecatamphetamine.github.io/country-flag-icons/3x2/${currCountry.substring(0, 2).toUpperCase()}.svg`;
 }
+function UrlExists(url) {
+    var http = new XMLHttpRequest();
+    http.open('HEAD', url, false);
+    http.send();
+    if (http.status != 404)
+        return true;
+    else
+        return false;
+}
 
 const style = {
-    flagImg: { margin: "0 10px 0px 0px", width: '35px' },
+    flagImg: { margin: "0 10px 0px 0px", width: '35px', background: '#c6c6c6'},
+    divGetFlag: { fontSize: '0.6rem', textAlign: 'center', padding: '5.5px 0px', fontWeight: 'bolder'},
 }

--- a/frontend/src/util/getFlag.js
+++ b/frontend/src/util/getFlag.js
@@ -1,26 +1,26 @@
 export function getFlag(currCountry) {
-    if (currCountry == null || currCountry.substring(0, 1) === "X") {
+    if (isValidParam(currCountry))
+        return <img style={style.flagImg} src={getBaseUrl(currCountry)} alt=""/>
+    else
         return <div style={{...style.flagImg, ...style.divGetFlag}} >{currCountry}</div>
-    } else {
-        const url = getBaseUrl(currCountry);
-        if (UrlExists(url))
-            return <img style={style.flagImg} src={getBaseUrl(currCountry)} alt=""/>
-        else
-            return <div style={{...style.flagImg, ...style.divGetFlag}} >{currCountry}</div>
-    }
 };
+
+const isValidParam = (currCountry) => {
+    if (!(currCountry == null || currCountry.substring(0, 1) === "X") && isUrlExists(getBaseUrl(currCountry)))
+        return true;
+    else 
+        return false;
+}
 
 const getBaseUrl = (currCountry) => {
     return `https://purecatamphetamine.github.io/country-flag-icons/3x2/${currCountry.substring(0, 2).toUpperCase()}.svg`;
 }
-function UrlExists(url) {
-    var http = new XMLHttpRequest();
-    http.open('HEAD', url, false);
-    http.send();
-    if (http.status != 404)
-        return true;
-    else
-        return false;
+
+const isUrlExists = (url) => {
+    var req = new XMLHttpRequest();
+    req.open('HEAD', url, false);
+    req.send();
+    return req.status === 200;
 }
 
 const style = {


### PR DESCRIPTION
Frontend changes:
- Updated main nav page, added the Dashboard tab, set it as default (home page) and removed the About tab.
- Added logic to display shorter nav tab labels based on the screen's width.
- Remove the Dense feature of the Live Rate Table setter.
- Added logic to reduce the frequency of sending requests to the backend for retrieving new rate data from API.
- Added logic to increase timer accuracy. It appears that the circular timer is divided into 100 ticks which cannot divided into 60 as a whole number and earlier the 60th second is also included.
- Added logic to refresh the current page when the user clicks on the current page's nav tab.
- handle null reference when there is no time series response for the display chart code logic.
- Handle the image tag's src return 404 status to display in text instead of a broken image icon.

Backend changes:
- Implemented new API key-getter logic. This will be invoked when the current key cannot retrieve any data from API, could be caused by running out of quota) when no data is returned.
- Implement logic to read the seeding files, that are stored locally, when in dev. environment, by providing a JSON reader helper class called JsonSeedFilesReader class in the Utilities folder. 

- Fixed bugs in previous PR
    - Delete a currency row button on the Live Rate table section. 