### PR TITLE
Retrieved timeSerie only once by having a memo list and only reset memo list's element that match with update curr request from frontend

### DIFF
--- a/backend/backend/ApiClients/CurrencyBeacon/CurrencyBeaconApiClient.cs
+++ b/backend/backend/ApiClients/CurrencyBeacon/CurrencyBeaconApiClient.cs
@@ -97,27 +97,6 @@ public class CurrencyBeaconApiClient : IExchangeRateApiClient
         return sortedRateTimeSeries;
     }
 
-    private string GetStartingDate(string timeSeriesRange)
-    {
-        DateTime offsetToday = default;
-        DateTime today = DateTime.Today;
-        if (timeSeriesRange.ToLower().Equals("1d"))
-            offsetToday = today.AddDays(-1);
-        else if (timeSeriesRange.ToLower().Equals("1w"))
-            offsetToday = today.AddDays(-6);
-        else if (timeSeriesRange.ToLower().Equals("1m"))
-            offsetToday = today.AddMonths(-1);
-        else if (timeSeriesRange.ToLower().Equals("3m"))
-            offsetToday = today.AddMonths(-3);
-        else if (timeSeriesRange.ToLower().Equals("6m"))
-            offsetToday = today.AddMonths(-6);
-        else if (timeSeriesRange.ToLower().Equals("1y"))
-            offsetToday = today.AddYears(-1);
-
-        var startDate = offsetToday.ToString("yyyy-MM-dd", CultureInfo.CreateSpecificCulture("en-US"));
-        return startDate;
-    }
-
     private Dictionary<string, CurrCountriesResponse> TransformedCurrCountriesResData(CurrencyBeaconCurrCountriesApiResponse currCountriesRes)
     {
         CurrencyBeaconCurrCountriesApiResponseResponse[] data = currCountriesRes.Response;

--- a/backend/backend/ApiClients/CurrencyBeacon/CurrencyBeaconApiClient.cs
+++ b/backend/backend/ApiClients/CurrencyBeacon/CurrencyBeaconApiClient.cs
@@ -80,7 +80,7 @@ public class CurrencyBeaconApiClient : IExchangeRateApiClient
 
     public async Task<SortedList<string, double>> GetExchangeRatesTimeSeries(string baseCurr, string targetCurr, string timeSeriesRange)
     {
-        _logger.LogInformation($"Requesting for new TimeSeries object !!!");
+        _logger.LogInformation($"Requesting for new TimeSeries object of: {baseCurr} to {targetCurr}");
         CurrencyBeaconTimeSeriesApiResponse[] rateTimeSeriesApiResponseList = new CurrencyBeaconTimeSeriesApiResponse[2];
         string[] pathToJSON = new string[2];
         if (isDevelopment)

--- a/backend/backend/ApiKeysProvider.cs
+++ b/backend/backend/ApiKeysProvider.cs
@@ -3,8 +3,8 @@ namespace backend;
 public class ApiKeysProvider
 {
     private IConfiguration? _apiKeysConfiguration;
-    private ILogger<ApiKeysProvider> _logger;
-    private IWebHostEnvironment _env;
+    private readonly ILogger<ApiKeysProvider> _logger;
+    private readonly IWebHostEnvironment _env;
     private string CurrentKey { get; set; } = "";
     private List<string> FailKeyList { get; set; } = new();
 

--- a/backend/backend/Controllers/CurrController.cs
+++ b/backend/backend/Controllers/CurrController.cs
@@ -60,8 +60,9 @@ public class CurrController : ControllerBase
         string baseCurr = data.BaseCurr;
         string targetCurr = data.TargetCurr;
         string timeSeriesRange = data.TimeSeriesRange;
+        bool isNewUpdateRequest = data.IsNewUpdateRequest;
         Dictionary<string, RateTimeSeriesResponse> result =
-            await _currService.GetExchangeRatesTimeSeries(baseCurr, targetCurr, timeSeriesRange);
+            await _currService.GetExchangeRatesTimeSeries(baseCurr, targetCurr, timeSeriesRange, isNewUpdateRequest);
         return result;
     }
 }

--- a/backend/backend/Controllers/CurrController.cs
+++ b/backend/backend/Controllers/CurrController.cs
@@ -47,9 +47,9 @@ public class CurrController : ControllerBase
     [HttpGet("currency-country")]
     public async Task<Dictionary<string, CurrCountriesResponse>> GetCurrCountriesFromCurrencyBeacon()
     {
-        _logger.LogInformation("Received request from frontend!!!");
+        //_logger.LogInformation("Received request from frontend!!!");
         var result = await _currService.GetCurrCountries();
-        _logger.LogInformation($"Response back data: {result}");
+        //_logger.LogInformation($"Response back data: {result}");
         return result;
     }
 

--- a/backend/backend/Models/RateTimeSeriesRequest.cs
+++ b/backend/backend/Models/RateTimeSeriesRequest.cs
@@ -10,4 +10,6 @@ public class RateTimeSeriesRequest
     public string TargetCurr { set; get; }
     [JsonPropertyName("timeSeriesRange")]
     public string TimeSeriesRange { set; get; }
+    [JsonPropertyName("isNewUpdateRequest")]
+    public bool IsNewUpdateRequest { set; get; }
 }

--- a/backend/backend/Services/CurrService.cs
+++ b/backend/backend/Services/CurrService.cs
@@ -72,9 +72,8 @@ public class CurrService
     public async Task<Dictionary<string, RateTimeSeriesResponse>> GetExchangeRatesTimeSeries(string baseCurr, string targetCurr, string timeSeriesRange, bool isNewUpdateRequest)
     {
         Dictionary<string, RateTimeSeriesResponse> targetCurrTimeSeries;
-        if (isNewUpdateRequest)
-            RangeByCurrTimeSeriesLists = new();
-        else if (RangeByCurrTimeSeriesLists.ContainsKey(timeSeriesRange))
+
+        if (!isNewUpdateRequest && RangeByCurrTimeSeriesLists.ContainsKey(timeSeriesRange))
         {
             List<Dictionary<string, RateTimeSeriesResponse>> allCurrTimeSeriesList = RangeByCurrTimeSeriesLists.FirstOrDefault(t => t.Key.Equals(timeSeriesRange)).Value;
             targetCurrTimeSeries = allCurrTimeSeriesList.FirstOrDefault(t => t.Keys.Equals(targetCurr));
@@ -106,7 +105,22 @@ public class CurrService
         {
             List<Dictionary<string, RateTimeSeriesResponse>> allCurrTimeSeriesList = RangeByCurrTimeSeriesLists[timeSeriesRange];
             if (allCurrTimeSeriesList != null && allCurrTimeSeriesList.Any())
-                allCurrTimeSeriesList.Add(targetCurrTimeSeries);
+            {
+                if (isNewUpdateRequest)
+                {
+                    for (int i = 0; i < allCurrTimeSeriesList.Count(); i++)
+                    {
+                        // if the currTimeSeries's key existed in the list, update its value and stop iteration
+                        if (allCurrTimeSeriesList[i].Keys.Equals(targetCurrTimeSeries.Keys))
+                        {
+                            allCurrTimeSeriesList[i] = targetCurrTimeSeries;
+                            break;
+                        }
+                    }
+                }
+                else
+                    allCurrTimeSeriesList.Add(targetCurrTimeSeries);
+            }
             else
                 allCurrTimeSeriesList = new List<Dictionary<string, RateTimeSeriesResponse>>() { targetCurrTimeSeries };
         }

--- a/backend/backend/Services/TimeseriesTransformer.cs
+++ b/backend/backend/Services/TimeseriesTransformer.cs
@@ -1,39 +1,50 @@
 using System.Globalization;
 using backend.Interfaces;
 using backend.Models;
+using backend.Utilities;
 
 namespace backend.Services;
 
 public class TimeseriesTransformer
 {
     private readonly IEnumerable<IExchangeRateApiClient> _exchangeRateApiClients;
+    private readonly IWebHostEnvironment _env;
 
-    public TimeseriesTransformer(IEnumerable<IExchangeRateApiClient> exchangeRateApiClients)
+    public TimeseriesTransformer(IEnumerable<IExchangeRateApiClient> exchangeRateApiClients, IWebHostEnvironment env)
     {
+        _env = env;
         _exchangeRateApiClients = exchangeRateApiClients.ToList();
     }
     
-    public Dictionary<string, RateTimeSeriesResponse> TransformedData (SortedList<string, double> timeSeries, string targetCurr)
+    public Dictionary<string, RateTimeSeriesResponse> TransformedData (SortedList<string, double> timeSeries, string targetCurr, string targetDateRange)
     {
         Dictionary<string, RateTimeSeriesResponse> targetCurrTimeSeries = new Dictionary<string, RateTimeSeriesResponse>();
-        int range = timeSeries!.Count;
+        string targetOffsetDate = DateGetter.OffsetDateFromToday(targetDateRange, _env).ToString("yyyy-MM-dd");
+        int range = timeSeries.Count() - timeSeries.IndexOfKey(targetOffsetDate); // total size (the last day key) - the offset date key
         string[] dayRange = new string[range];
         string[] monthRange = new string[range];
         double[] changingRates = new double[range];
-        int i = 0;
-        
-        foreach (var element in timeSeries)
+        int index = range - 1;
+
+        try
         {
-            string fullDate = element.Key; // return yyyy-MM-dd
-            string year = fullDate.Substring(0, 4); // get yyyy
-            int monthNum = int.Parse(fullDate.Substring(5, 2)); // get MM
-            string monthAbbr = CultureInfo.CurrentCulture.DateTimeFormat.GetAbbreviatedMonthName(monthNum); // get the abbr. of the month
-            string day = fullDate.Substring(fullDate.Length - 2); // get dd
-            dayRange[i] = day + " " + monthAbbr;
-            monthRange[i] = monthAbbr + " " + year;
-            double rate = element.Value; // return rate
-            changingRates[i] = rate;
-            i++;
+            for (int i = timeSeries.Count() - 1; i >= timeSeries.IndexOfKey(targetOffsetDate); i--)
+            {
+                string fullDate = timeSeries.Keys[i]; // return yyyy-MM-dd
+                string year = fullDate.Substring(0, 4); // get yyyy
+                int monthNum = int.Parse(fullDate.Substring(5, 2)); // get MM
+                string monthAbbr = CultureInfo.CurrentCulture.DateTimeFormat.GetAbbreviatedMonthName(monthNum); // get the abbr. of the month
+                string day = fullDate.Substring(fullDate.Length - 2); // get dd
+                dayRange[index] = day + " " + monthAbbr;
+                monthRange[index] = monthAbbr + " " + year;
+                double rate = timeSeries.Values[i]; // return rate
+                changingRates[index] = rate;
+                index--;
+            }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
         }
         
         double highest = changingRates.Max();

--- a/backend/backend/Services/TimeseriesTransformer.cs
+++ b/backend/backend/Services/TimeseriesTransformer.cs
@@ -45,6 +45,7 @@ public class TimeseriesTransformer
         catch (Exception e)
         {
             Console.WriteLine(e);
+            return null;
         }
         
         double highest = changingRates.Max();

--- a/backend/backend/Utilities/DateGetter.cs
+++ b/backend/backend/Utilities/DateGetter.cs
@@ -1,0 +1,69 @@
+﻿using System.Globalization;
+
+namespace backend.Utilities;
+
+public class DateGetter
+{
+    string[] dateRanges = { "1d", "1w", "1m", "3m", "6m" };//, "9m", "1y" };
+
+    public DateGetter()
+    {
+    }
+
+    public string[] GetDateRange()
+    {
+        return dateRanges;
+    }
+
+    public static string GetTodayOffsetDateInString(string timeSeriesRange, IWebHostEnvironment env)
+    {
+        DateTime offsetToday = OffsetDateFromToday(timeSeriesRange, env);
+        var startDate = offsetToday.ToString("yyyy-MM-dd", CultureInfo.CreateSpecificCulture("en-US"));
+        return startDate;
+    }
+
+    public static DateTime OffsetDateFromToday(string timeSeriesRange, IWebHostEnvironment env)
+    {
+        DateTime offsetToday = default;
+        DateTime today = env == null ? DateTime.Today : Convert.ToDateTime("2024-06-11", new CultureInfo("en-US"));
+        switch (timeSeriesRange.ToLower())
+        {
+            case "1d":
+                offsetToday = today.AddDays(-1);
+                break;
+            case "1w":
+                offsetToday = today.AddDays(-6);
+                break;
+            case "1m":
+                offsetToday = today.AddMonths(-1);
+                break;
+            case "3m":
+                offsetToday = today.AddMonths(-3);
+                break;
+            case "6m":
+                offsetToday = today.AddMonths(-6);
+                break;
+            case "9m":
+                offsetToday = today.AddMonths(-9);
+                break;
+            case "1y":
+                offsetToday = today.AddYears(-1);
+                break;
+        }
+        return offsetToday;
+    }
+
+    //public static Dictionary<string, DateTime> GetDateRangeByOffsetDateList()
+    //{
+    //    Dictionary<string, DateTime> dateRangeByOffsetDateList = new();
+    //    string[] dateRanges = new DateGetter().GetDateRange();
+
+    //    foreach(var dateRange in dateRanges)
+    //    {
+    //        DateTime tempDateOffset = DateGetter.OffsetDateFromToday(dateRange);
+    //        dateRangeByOffsetDateList.Add(dateRange, tempDateOffset);
+    //    }
+    //    return dateRangeByOffsetDateList;
+    //}
+}
+

--- a/backend/backend/Utilities/DateGetter.cs
+++ b/backend/backend/Utilities/DateGetter.cs
@@ -4,7 +4,7 @@ namespace backend.Utilities;
 
 public class DateGetter
 {
-    string[] dateRanges = { "1d", "1w", "1m", "3m", "6m" };//, "9m", "1y" };
+    string[] dateRanges = { "1d", "1w", "1m", "3m", "6m", "9m", "1y" };
 
     public DateGetter()
     {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import MainNav from './components/MainNav';
 import Convertor from './components/Convertor/Convertor';
 import ExchangeRateTable from './components/ExchangeRateTable/ExchangeRateTable';

--- a/frontend/src/components/Convertor/Convertor.js
+++ b/frontend/src/components/Convertor/Convertor.js
@@ -87,7 +87,6 @@ export default function Convertor(props) {
                             {displayFeature &&
                                 <div style={style.divChart} >
                                     <Box sx={{ ...sxStyle.lineGraph, height: !isDisplaySM && "300px" }}>
-                                        {console.log("logging timeSeries: ", timeSeries)}
                                         <LineGraph timeSeries={timeSeries} displayLabel={true} />
                                     </Box>
                                         <div style={{ ...style.divRangeTimeSeriesSelector, marginTop: isDisplaySM ? "4%" : "2.5%", display: !displayFeature && "none" }}>

--- a/frontend/src/components/Convertor/Convertor.js
+++ b/frontend/src/components/Convertor/Convertor.js
@@ -21,6 +21,7 @@ export default function Convertor(props) {
     const [formData, setFormData] = useState(null);
     const [timeSeries, setTimeSeries] = useState(null);
     const [timeSeriesRange, setTimeSeriesRange] = useState("1d");
+    const [isNewUpdateRequest, setIsNewUpdateRequest] = useState(true);
     const displayFeature = currentUrl.pathname.toLowerCase().includes("convert");
 
     let baseCurr;
@@ -45,7 +46,7 @@ export default function Convertor(props) {
     useEffect(() => {
         if (formData != null) {
             async function timeSeriesGetter() {
-                const timeSeriesRes = await retrieveExchangeRatesTimeSeries(baseCurr, targetCurr, timeSeriesRange);
+                const timeSeriesRes = await retrieveExchangeRatesTimeSeries(baseCurr, targetCurr, timeSeriesRange, isNewUpdateRequest);
                 setTimeSeries(timeSeriesRes.data[targetCurr])
             }
             timeSeriesGetter()
@@ -54,6 +55,7 @@ export default function Convertor(props) {
     )
 
     const setFormDataToConvertor = (inputData, response) => {
+        setIsNewUpdateRequest(true);
         setFormData(() => {
             return {
                 ...inputData, total: response.data
@@ -62,6 +64,7 @@ export default function Convertor(props) {
     }
 
     const handleClick = (range) => {
+        setIsNewUpdateRequest(false)
         setTimeSeriesRange(range)
     }
 

--- a/frontend/src/components/Convertor/RangeTimeSeriesSelector.js
+++ b/frontend/src/components/Convertor/RangeTimeSeriesSelector.js
@@ -8,7 +8,7 @@ import ToggleButtonGroup, {
 export default function RangeTimeSeriesSelector(props) {
     const { updateVal, isDisplaySM } = props;
     const [displayValue, setDisplayValue] = useState("1d")
-    const timeSeriesRanges = ["1d", "1w", "1m", "3m", "6m"];
+    const timeSeriesRanges = ["1d", "1w", "1m", "3m", "6m", "9m", "1y"];
 
     const handleChange = (event, newDisplayValue) => {
         updateVal(newDisplayValue);

--- a/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
+++ b/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
@@ -40,7 +40,6 @@ export default function ExchangeRateTableData(props) {
     const [order, setOrder] = useState('desc');
     const [orderBy, setOrderBy] = useState('');
     const [page, setPage] = useState(0);
-    const [dense, setDense] = useState(false);
     const [rowsPerPage, setRowsPerPage] = useState(5);
     const [triggerNewTimeDisplay, setTriggerNewTimeDisplay] = useState(false);
 
@@ -226,7 +225,7 @@ export default function ExchangeRateTableData(props) {
                         <Table
                             sx={isDisplaySM ? { whiteSpace: "nowrap", padding: "0" } : sxStyle.Table}
                             aria-labelledby="tableTitle"
-                            size={dense ? 'small' : 'medium'}
+                            size='medium'
                         >
                             <EnhancedTableHead
                                 order={order}

--- a/frontend/src/util/apiClient.js
+++ b/frontend/src/util/apiClient.js
@@ -19,8 +19,8 @@ export async function retrieveExchangeRates(initialValue) {
     return [resExchangeRatesLast.data, resExchangeRatesHist.data];
 }
 
-export async function retrieveExchangeRatesTimeSeries(baseCurr, targetCurr, timeSeriesRange) {
-    const resExchangeRatesTimeSeries = await axios.post(`${baseURL}:${port}/curr/rate-timeSeries`, { baseCurr, targetCurr, timeSeriesRange });
+export async function retrieveExchangeRatesTimeSeries(baseCurr, targetCurr, timeSeriesRange, isNewUpdateRequest) {
+    const resExchangeRatesTimeSeries = await axios.post(`${baseURL}:${port}/curr/rate-timeSeries`, { baseCurr, targetCurr, timeSeriesRange, isNewUpdateRequest });
     return resExchangeRatesTimeSeries;
 }
 

--- a/frontend/src/util/createCurrLists.js
+++ b/frontend/src/util/createCurrLists.js
@@ -21,7 +21,7 @@ export async function createCurrLists(baseCurr, targetCurr, currApiDataSet, time
 }
 
 async function sendTimeSeriesReq(baseCurr, targetCurr, timeSeriesRange) {
-    const timeSeriesRes = await retrieveExchangeRatesTimeSeries(baseCurr, targetCurr, timeSeriesRange);
+    const timeSeriesRes = await retrieveExchangeRatesTimeSeries(baseCurr, targetCurr, timeSeriesRange, true);
     return timeSeriesRes.data[targetCurr];
 }
 


### PR DESCRIPTION
- Implemented a new DateGetter util class and moved the GetStartingDate() from CurrencyBeaconApiClient into the DateGetter class since the CurrService class also needs to invoke the function.
- Implemented requesting TimeSerie from API data source only once by requesting a 1-year range of time series object, it will cover all range of time-series requests from the frontend -> reduce to request once per new update request.
    - Added logic to get the correct size of offsetDate for initializing arrays and partition data from the end of the SortedList object.
    -  Added logic to memorize and keep all the timeSeries objects from earlier requests. There is no need to fetch new data every time since the front end only requires updating new data every 15 minutes.
    - Added logic to combine 2 JSON objects into 1.
- Update logic to get data from JSON static test file correctly
    - Added logic not to get today's date if it is dev env, since we only test with static JSON files.
    - Added logic to retrieve data from JSON files based on the time range of frontend requests.
- enable the more range selector for displaying the timeSerie chart.