### PR TITLE
Fixed styling bug on safari browser

### DIFF
--- a/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
+++ b/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
@@ -434,7 +434,7 @@ const style = {
     Tooltip: { margin: "16px" },
     PaperDiv: { display: "flex" },
     NoGapTableContainer: { marginTop: "-15px" },
-    TableRow: { width: "100%", whiteSpace: "nowrap" },
+    TableRow: { width: "100%", whiteSpace: "nowrap", transform: 'translate(0)' },
     TableCell: {
         lg: { width: "20%", ...commonStyle.borderNone },
         sm: { width: "10%", padding: "0px 0px 10px 10px", ...commonStyle.borderNone }
@@ -459,7 +459,7 @@ const sxStyle = {
         sm: { margin: "0px 10px", padding: "0px" },
     },
     hoverButton: {
-        main: { height: '-webkit-fill-available', borderRadius: '7px', transition: 'background 0.3s', },
+        main: { height: '-webkit-fill-available', borderRadius: '7px', transition: 'background 0.3s', display: 'flex', alignItems: 'center'},
         hover: { '&:hover': { background: '#9fbee354', margin: '0.5px', borderRadius: '10px', transition: 'background 0.6s' } },
     },
     PaginationMainContainer: {

--- a/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
+++ b/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
@@ -314,7 +314,7 @@ export default function ExchangeRateTableData(props) {
                                                         </Button>
                                                     </Box>
                                                 </TableCell>
-                                                <TableCell colSpan={isDisplaySM ? 2 : 3} sx={{ ...commonStyle.paddingNone, ...commonStyle.borderNone, ...(index !== 0 && isFeatureDisplay && sxStyle.hoverButton.hover) }}>
+                                                <TableCell colSpan={isDisplaySM ? 2 : 3} sx={{ ...commonStyle.paddingNone, ...commonStyle.borderNone, ...(index !== 0 && !isDisplaySM && isFeatureDisplay && sxStyle.hoverButton.hover) }}>
                                                     <Table>
                                                         <TableBody>
                                                             <TableRow>

--- a/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
+++ b/frontend/src/components/ExchangeRateTable/ExchangeRateTableData.js
@@ -294,12 +294,12 @@ export default function ExchangeRateTableData(props) {
                                                     component="th"
                                                     id={labelId}
                                                     scope="row"
-                                                    sx={{ ...commonStyle.paddingNone, ...commonStyle.borderNone, ...style.TableCell }}
+                                                    onClick={() => handleSetDefaultCurr(targetCurrCode)}
+                                                    sx={{ ...commonStyle.paddingNone, ...commonStyle.borderNone, ...style.TableCell, ...(index !== 0 && sxStyle.hoverButton.hover) }}
                                                 >
-                                                    <Box sx={{ ...sxStyle.hoverButton.main, ...(index !== 0 && sxStyle.hoverButton.hover) }}>
+                                                    <Box sx={{ ...sxStyle.hoverButton.main }}>
                                                         <Button
                                                             variant="text"
-                                                            onClick={() => handleSetDefaultCurr(targetCurrCode)}
                                                             disabled={index === 0 && true}
                                                             sx={{
                                                                 ...sxStyle.defaultCurrSetterButton.main,

--- a/frontend/src/components/subComponents/CircularProgressWithLabel.js
+++ b/frontend/src/components/subComponents/CircularProgressWithLabel.js
@@ -100,7 +100,7 @@ export default function CircularWithValueLabel(props) {
 const sxStyle = {
     Container: { display: 'flex', alignItems: 'center' },
     Box: { position: 'relative', display: 'inline-flex' },
-    CircularGrey: { color: (theme) => theme.palette.grey[theme.palette.mode === 'light' ? 200 : 800] },
+    CircularGrey: { color: (theme) => theme.palette.grey[theme.palette.mode === 'light' ? 200 : 800], '& svg': { position: 'inherit' } },
     CenterPos: {
         top: 0, left: 0, bottom: 0, right: 0, position: 'absolute', display: 'flex', alignItems: 'center',
         justifyContent: 'center'

--- a/frontend/src/components/subComponents/CircularProgressWithLabel.js
+++ b/frontend/src/components/subComponents/CircularProgressWithLabel.js
@@ -20,7 +20,7 @@ function CircularProgressWithLabel(props) {
                 <Box
                     sx={sxStyle.CenterPos}
                 >
-                    <Typography variant="button" component="div" color="text.secondary">
+                    <Typography variant="BUTTON" component="div" color="text.secondary">
                         {`${Math.round(props.value / 1.6667)}`}
                     </Typography>
                 </Box>
@@ -100,7 +100,7 @@ export default function CircularWithValueLabel(props) {
 const sxStyle = {
     Container: { display: 'flex', alignItems: 'center' },
     Box: { position: 'relative', display: 'inline-flex' },
-    CircularGrey: { color: (theme) => theme.palette.grey[theme.palette.mode === 'light' ? 200 : 800], '& svg': { position: 'inherit' } },
+    CircularGrey: { color: (theme) => theme.palette.grey[theme.palette.mode === 'light' ? 300 : 800], '& svg': { position: 'inherit' } },
     CenterPos: {
         top: 0, left: 0, bottom: 0, right: 0, position: 'absolute', display: 'flex', alignItems: 'center',
         justifyContent: 'center'

--- a/frontend/src/components/subComponents/RangeTimeSeriesSelector.js
+++ b/frontend/src/components/subComponents/RangeTimeSeriesSelector.js
@@ -67,6 +67,6 @@ const commonStyle = {
 }
 
 const style = {
-    sm: { ...commonStyle, width: '60%', overflow: 'scroll' },
+    sm: { ...commonStyle, width: '65%', overflow: 'scroll' },
     lg: { ...commonStyle },
 }


### PR DESCRIPTION
- Fixed styling for safari, including:
    - Table row's transform and not middle alignment issue
    - Timer's grey bar is hidden
    - rangeSelection size
- implement onClick to the whole cell wrapper instead of sub-cell for displaying a chart and disable hover when on mobile screen