### PR TITLE
Keep Load data update when switch tab

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -37,7 +37,7 @@ export default function App() {
     useEffect(() => {
         async function fetchPreference() {
             if (userPreference === null) {
-                console.log("Get initial Pref!!!")
+                // console.log("Get initial Pref!!!")
                 const pref = await getUserPreferences(userId);
                 const newsRes = await retrieveFinancialNews(pref.newsCategories);
                 setUserPreference(pref);

--- a/frontend/src/components/Convertor/Convertor.js
+++ b/frontend/src/components/Convertor/Convertor.js
@@ -16,7 +16,7 @@ export default function Convertor(props) {
     let baseCurr = "", targetCurr = "", amount = 0.0, total = 0.0; // declare default variable to insert into the markup content
 
     useEffect(() => {
-        console.log("Reassign initial convertPair to dropdown (when userPref not null)!!!")
+        // console.log("Reassign initial convertPair to dropdown (when userPref not null)!!!")
         setTargetConvertCurrPair([...userPreference.convertedCurrPair])
     }, [userPreference])
 

--- a/frontend/src/components/ExchangeRateTable/ExchangeRateTable.js
+++ b/frontend/src/components/ExchangeRateTable/ExchangeRateTable.js
@@ -78,15 +78,12 @@ export default function ExchangeRateTable(props) {
         }
     }, [isReady]);
 
-    // Update new added currency code to visibl row
+    // Fetch the latest CurrCodeArray and CurrLists from cookie.
+    // This is needed since react fetch all all the neccessary data once, where the new update will be brought along 
+    // when user switch to different tab.
     useEffect(() => {
-        async function checkNewRow() {
-            // console.log("refresh page!!!");
-            if (newCurrCode !== "" && !checkIfExist(currLists, newCurrCode)) {
-                updateCurrCodeArray()
-                await updateCurrLists()
-            }
-            else if (isInitialLoad) {
+        async function fetchUpdateOnInitialLoad() {
+            if (isInitialLoad) { // THIS NEED TO BREAK INTO ITS USEEFFECT
                 const newPref = await getUserPreferences(userId);
                 const newCurrCodeArray = newPref.liveRateCurrCodes;
                 const newCurrLists = await getCurrListsFromCookie(userId);
@@ -94,12 +91,24 @@ export default function ExchangeRateTable(props) {
                 setCurrLists(newCurrLists);
                 setIsInitialLoad(false);
             }
+        }
+        fetchUpdateOnInitialLoad();
+    }, [isInitialLoad, userId])
+
+    // Update new added currency code to visible row
+    useEffect(() => {
+        async function checkNewRow() {
+            // console.log("refresh page!!!");
+            if (newCurrCode !== "" && !checkIfExist(currLists, newCurrCode)) {
+                updateCurrCodeArray()
+                await updateCurrLists()
+            }
             setNewCurrCode("");
             // console.log("Check Curr Lists after refresh page: ", currLists);
             // console.log("Check Curr Array after refresh page: ", currCodeArray);
         }
         checkNewRow();
-    }, [newCurrCode, currLists, defaultCurrExchangeRates, defaultCurrCode, currCodeArray, isChartFeatureEnable, userId, isInitialLoad]);
+    }, [newCurrCode, currLists, defaultCurrExchangeRates, defaultCurrCode, currCodeArray, isChartFeatureEnable, userId]);
 
     // refresh time display on screen when any time-related property is updated
     useEffect(() => {

--- a/frontend/src/components/FinancialNews/FinancialNews.js
+++ b/frontend/src/components/FinancialNews/FinancialNews.js
@@ -12,7 +12,7 @@ import Button from '@mui/material/Button';
 import InputTextField from "../subComponents/InputTextField";
 import { Loading } from '../subComponents/Loading';
 import FinancialNewsLists from "./FinancialNewsLists";
-import { savePrefNewsCategories } from "../../hook/userController";
+import { getUserPreferences, savePrefNewsCategories } from "../../hook/userController";
 
 export default function FinancialNews(props) {
     const { filter = false, isDisplaySM, isOutLineTheme = true, userId, userPreference, newsListsRes } = props;
@@ -24,10 +24,13 @@ export default function FinancialNews(props) {
 
     useEffect(() => {
         async function fetchNewsLists() {
+            // console.log("--  >>> fetchNewsLists!!! ", newCategories)
             if (!isInitialLoad) { // Do not fetch new newsList if set new theme
                 const newsRes = await retrieveFinancialNews(newCategories);
                 setNewsHeadlinesList(newsRes.data);
             } else {
+                const newPref = await getUserPreferences(userId);
+                setNewCategories(newPref.newsCategories);
                 setIsInitialLoad(false);
             }
         }

--- a/frontend/src/hook/userController.js
+++ b/frontend/src/hook/userController.js
@@ -84,7 +84,7 @@ export async function saveCurrListsToCookie(userId, currLists) {
 // Invoke to update the initialCurrList whenever user set new theme
 export function getCurrListsFromCookie(userId) {
     const savedCurrLists = localStorage.getItem(`currLists_${userId}`);
-    console.log("check savedCurrLists: ", savedCurrLists)
+    // console.log("check savedCurrLists: ", savedCurrLists)
     // Check if savedData has any
     if (savedCurrLists)
         return JSON.parse(savedCurrLists);


### PR DESCRIPTION
- fetch new data when switching tabs by adding fetch logic in useEffect. The state will be updated when not match with cookie's content. This applied to both the LiveRate table and news sub-components.